### PR TITLE
Correct MIME type for .bmp images

### DIFF
--- a/MimeDetective/MimeTypes.cs
+++ b/MimeDetective/MimeTypes.cs
@@ -66,12 +66,12 @@ namespace MimeDetective
         public readonly static FileType JPEG = new FileType(new byte?[] { 0xFF, 0xD8, 0xFF }, "jpg", "image/jpeg");
         public readonly static FileType PNG = new FileType(new byte?[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, "png", "image/png");
         public readonly static FileType GIF = new FileType(new byte?[] { 0x47, 0x49, 0x46, 0x38, null, 0x61 }, "gif", "image/gif");
-        public readonly static FileType BMP = new FileType(new byte?[] { 66, 77 }, "bmp", "image/gif");
+        public readonly static FileType BMP = new FileType(new byte?[] { 0x42, 0x4D }, "bmp", "image/bmp"); // or image/x-windows-bmp
         public readonly static FileType ICO = new FileType(new byte?[] { 0, 0, 1, 0 }, "ico", "image/x-icon");
-
+        //tiff
+        
         #endregion
 
-        //bmp, tiff
         #region Zip, 7zip, rar, dll_exe, tar, bz2, gz_tgz
 
         public readonly static FileType GZ_TGZ = new FileType(new byte?[] { 0x1F, 0x8B, 0x08 }, "gz, tgz", "application/x-gz");


### PR DESCRIPTION
Proper bmp MIME type and decimal values converted to its hexadecimal equivalent.
See issue #11.
