### PR TITLE
Apply MIT license on files; issue #4

### DIFF
--- a/MimeDetective/Extensions/ArchiveExtensions.cs
+++ b/MimeDetective/Extensions/ArchiveExtensions.cs
@@ -1,4 +1,28 @@
-﻿namespace MimeDetective.Extensions.Archives
+﻿//
+// The MIT License (MIT)
+// 
+// Copyright (C) 2014  Muraad Nofal and the contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+namespace MimeDetective.Extensions.Archives
 {
     using System.IO;
 

--- a/MimeDetective/Extensions/DocumentExtensions.cs
+++ b/MimeDetective/Extensions/DocumentExtensions.cs
@@ -1,4 +1,28 @@
-﻿namespace MimeDetective.Extension.Documents
+﻿//
+// The MIT License (MIT)
+// 
+// Copyright (C) 2014  Muraad Nofal and the contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+namespace MimeDetective.Extension.Documents
 {
     using System.IO;
 

--- a/MimeDetective/Extensions/GraphicsExtensions.cs
+++ b/MimeDetective/Extensions/GraphicsExtensions.cs
@@ -1,4 +1,28 @@
-﻿namespace MimeDetective.Extensions.Graphics
+﻿//
+// The MIT License (MIT)
+// 
+// Copyright (C) 2014  Muraad Nofal and the contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+namespace MimeDetective.Extensions.Graphics
 {
     using System.IO;
 

--- a/MimeDetective/FileType.cs
+++ b/MimeDetective/FileType.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿//
+// The MIT License (MIT)
+// 
+// Copyright (C) 2014  Muraad Nofal and the contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+using System;
 
 namespace MimeDetective
 {

--- a/MimeDetective/MimeDetective.cs
+++ b/MimeDetective/MimeDetective.cs
@@ -1,21 +1,26 @@
-﻿/*
-    Copyright (C) 2014  Muraad Nofal
-    Contact: muraad.nofal@gmail.com
- 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
- * */
+﻿//
+// The MIT License (MIT)
+// 
+// Copyright (C) 2014  Muraad Nofal and the contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
 
 using System;
 using System.Collections.Generic;

--- a/MimeDetective/MimeTypes.cs
+++ b/MimeDetective/MimeTypes.cs
@@ -1,4 +1,28 @@
-﻿using System;
+﻿//
+// The MIT License (MIT)
+// 
+// Copyright (C) 2014  Muraad Nofal and the contributors
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 Mime-Detective
 ==============
 
-Mime type for files.
+Resolve MIME type for files.
 
 Based on https://filetypedetective.codeplex.com/
 
+License: MIT
+
+
 
 Usage 
+------------
 
 ```csharp
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,4 @@
-Mime-Detective
-==============
 
-Resolve MIME type for files.
+This fork is based on an abandoned fork.
 
-Based on https://filetypedetective.codeplex.com/
-
-License: MIT
-
-
-
-Usage 
-------------
-
-```csharp
-
-// Both ways are writing the data to a temp file
-// to get a FileInfo. GetFileType are extension methods
-byte[] fileData = ...;
-FileType fileType = fileData.GetFileType();
-   
-// or 
-Stream fileDataStream = ...;
-FileType fileType = fileDataStream.GetFileType();
-
-// If writing to a temp file is not practicable use it like this
-byte[] fileData = ...;
-FileType fileType = MimeTypes.GetFileType(() => fileData);
-   
-```
+See https://github.com/clarkis117/Mime-Detective for something fresh.


### PR DESCRIPTION
The issue #4 was about changing the license from GPL to MIT. The original author approved.
It was suggested to update the files with the license text. Here is the fix.